### PR TITLE
Camera on iPad/iPhone in Landscape Orientation:

### DIFF
--- a/SCIBarcodeScanner/View/SCIBarcodeScannerView.swift
+++ b/SCIBarcodeScanner/View/SCIBarcodeScannerView.swift
@@ -100,15 +100,15 @@ public class SCIBarcodeScannerView: UIView {
 
     public override func willMove(toSuperview newSuperview: UIView?) {
         NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(changed), name: UIDevice.orientationDidChangeNotification, object: nil)
+        if (self.currentTopViewController?.shouldAutorotate ?? true) {
+            NotificationCenter.default.addObserver(self, selector: #selector(orientationDidChanged), name: UIDevice.orientationDidChangeNotification, object: nil)
+        }
         self.setupCodeTypes()
         self.checkPermissions()
     }
 
-    @objc private func changed() {
-        if (self.currentTopViewController?.shouldAutorotate ?? true) {
+    @objc private func orientationDidChanged() {
             self.rotateVideoLayer()
-        }
     }
 
     public func toggleTorch() {

--- a/SCIBarcodeScanner/View/SCIBarcodeScannerView.swift
+++ b/SCIBarcodeScanner/View/SCIBarcodeScannerView.swift
@@ -108,7 +108,7 @@ public class SCIBarcodeScannerView: UIView {
     }
 
     @objc private func orientationDidChanged() {
-            self.rotateVideoLayer()
+        self.rotateVideoLayer()
     }
 
     public func toggleTorch() {

--- a/SCIBarcodeScanner/View/SCIBarcodeScannerView.swift
+++ b/SCIBarcodeScanner/View/SCIBarcodeScannerView.swift
@@ -192,7 +192,6 @@ public class SCIBarcodeScannerView: UIView {
 
         self.startCapture()
         self.setupScanBox()
-        self.rotateVideoLayer()
     }
 
     private func startCapture() {
@@ -239,33 +238,23 @@ public class SCIBarcodeScannerView: UIView {
     private func rotateVideoLayer() {
         guard let videoLayer = self.videoPreviewLayer else { return }
 
-        var connection = videoLayer.connection
-        if connection?.isVideoOrientationSupported != true {
-            connection = nil
-        }
-
         CATransaction.begin();
         CATransaction.setAnimationDuration(0.01)
         CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut));
 
         var transpose = false
-        switch UIDevice.current.orientation {
+        switch UIApplication.shared.statusBarOrientation {
         case .portrait:
-            connection?.videoOrientation = .portrait
             videoLayer.transform = CATransform3DMakeRotation(0.degreesToRadians, 0, 0, 1)
         case .landscapeLeft:
             transpose = true
-            connection?.videoOrientation = .portraitUpsideDown
             videoLayer.transform = CATransform3DMakeRotation(90.degreesToRadians, 0, 0, 1)
         case .landscapeRight:
             transpose = true
-            connection?.videoOrientation = .portraitUpsideDown
             videoLayer.transform = CATransform3DMakeRotation(270.degreesToRadians, 0, 0, 1)
         case .portraitUpsideDown:
-            connection?.videoOrientation = .portrait
             videoLayer.transform = CATransform3DMakeRotation(180.degreesToRadians, 0, 0, 1)
         default:
-            connection?.videoOrientation = .portrait
             videoLayer.transform = CATransform3DMakeRotation(0.degreesToRadians, 0, 0, 1)
         }
 

--- a/SCIBarcodeScanner/View/SCIBarcodeScannerView.swift
+++ b/SCIBarcodeScanner/View/SCIBarcodeScannerView.swift
@@ -101,13 +101,13 @@ public class SCIBarcodeScannerView: UIView {
     public override func willMove(toSuperview newSuperview: UIView?) {
         NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         if (self.currentTopViewController?.shouldAutorotate ?? true) {
-            NotificationCenter.default.addObserver(self, selector: #selector(orientationDidChanged), name: UIDevice.orientationDidChangeNotification, object: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(orientationDidChange), name: UIDevice.orientationDidChangeNotification, object: nil)
         }
         self.setupCodeTypes()
         self.checkPermissions()
     }
 
-    @objc private func orientationDidChanged() {
+    @objc private func orientationDidChange() {
         self.rotateVideoLayer()
     }
 


### PR DESCRIPTION
- fixed with function UIApplication.shared.statusBarOrientation
- dont need rotateViewLayer in setupCamera because of layoutSubviews will be called twice on start of the view

next steps:
- new version to bump
- update pod in other projects
- fix rotation on sellsite

closes #16 